### PR TITLE
Add real token generation instead of "asdfasdfasfasfasdfasdf"

### DIFF
--- a/lib/tyrant/authenticatable.rb
+++ b/lib/tyrant/authenticatable.rb
@@ -16,7 +16,7 @@ module Tyrant
 
     module Confirm
       def confirmable!
-        auth_meta_data.confirmation_token = "asdfasdfasfasfasdfasdf"
+        auth_meta_data.confirmation_token = SecureRandom.urlsafe_base64
         auth_meta_data.confirmation_created_at = DateTime.now
         self
       end


### PR DESCRIPTION
I don't know if it's the best way to do it. I used SecureRandom.urlsafe_base64. I tested it manually with my gemgem and… it's incredibly working ;)
