### PR TITLE
Replace the FakeWarden with the real one

### DIFF
--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -1,17 +1,6 @@
 require "test_helper"
 
 class SessionTest < MiniTest::Spec
-  class FakeWarden
-    attr_accessor :user
-    # TODO: replace with real warden.
-    alias_method :set_user, :user=
-    def logout
-      @user = nil
-    end
-  end
-
-  let (:warden) { FakeWarden.new }
-
   it do
     session = Tyrant::Session.new(warden)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,79 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'tyrant'
 
 require 'minitest/autorun'
+
+require 'warden'
+require 'rack-minitest/test'
+
+# Use Warden spec helper to simulate Warden
+# https://github.com/hassox/warden/blob/master/spec/helpers/request_helper.rb
+module Warden::Spec
+  module Helpers
+    FAILURE_APP = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["You Fail!"]] }
+
+    def env_with_params(path = "/", params = {}, env = {})
+      method = params.delete(:method) || "GET"
+      env = { 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => "#{method}" }.merge(env)
+      Rack::MockRequest.env_for("#{path}?#{Rack::Utils.build_query(params)}", env)
+    end
+
+    def setup_rack(app = nil, opts = {}, &block)
+      app ||= block if block_given?
+
+      opts[:failure_app]         ||= failure_app
+      opts[:default_strategies]  ||= [:password]
+      opts[:default_serializers] ||= [:session]
+      blk = opts[:configurator] || proc{}
+
+      Rack::Builder.new do
+        use opts[:session] || Warden::Spec::Helpers::Session unless opts[:nil_session]
+        use Warden::Manager, opts, &blk
+        run app
+      end
+    end
+
+    def valid_response
+      Rack::Response.new("OK").finish
+    end
+
+    def failure_app
+      Warden::Spec::Helpers::FAILURE_APP
+    end
+
+    def success_app
+      lambda{|e| [200, {"Content-Type" => "text/plain"}, ["You Win"]]}
+    end
+
+    class Session
+      attr_accessor :app
+      def initialize(app,configs = {})
+        @app = app
+      end
+
+      def call(e)
+        e['rack.session'] ||= {}
+        @app.call(e)
+      end
+    end # session
+  end
+end
+
+class MiniTest::Spec
+  include Warden::Spec::Helpers
+
+  before :all do
+    Warden.test_mode!
+  end
+
+  after do
+    Warden.test_reset!
+  end
+
+  def warden
+    @warden ||= begin
+      env = env_with_params
+      setup_rack(success_app).call(env)
+      env['warden']
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,77 +4,11 @@ require 'tyrant'
 require 'minitest/autorun'
 
 require 'warden'
-require 'rack-minitest/test'
-
-# Use Warden spec helper to simulate Warden
-# https://github.com/hassox/warden/blob/master/spec/helpers/request_helper.rb
-module Warden::Spec
-  module Helpers
-    FAILURE_APP = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["You Fail!"]] }
-
-    def env_with_params(path = "/", params = {}, env = {})
-      method = params.delete(:method) || "GET"
-      env = { 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => "#{method}" }.merge(env)
-      Rack::MockRequest.env_for("#{path}?#{Rack::Utils.build_query(params)}", env)
-    end
-
-    def setup_rack(app = nil, opts = {}, &block)
-      app ||= block if block_given?
-
-      opts[:failure_app]         ||= failure_app
-      opts[:default_strategies]  ||= [:password]
-      opts[:default_serializers] ||= [:session]
-      blk = opts[:configurator] || proc{}
-
-      Rack::Builder.new do
-        use opts[:session] || Warden::Spec::Helpers::Session unless opts[:nil_session]
-        use Warden::Manager, opts, &blk
-        run app
-      end
-    end
-
-    def valid_response
-      Rack::Response.new("OK").finish
-    end
-
-    def failure_app
-      Warden::Spec::Helpers::FAILURE_APP
-    end
-
-    def success_app
-      lambda{|e| [200, {"Content-Type" => "text/plain"}, ["You Win"]]}
-    end
-
-    class Session
-      attr_accessor :app
-      def initialize(app,configs = {})
-        @app = app
-      end
-
-      def call(e)
-        e['rack.session'] ||= {}
-        @app.call(e)
-      end
-    end # session
-  end
-end
 
 class MiniTest::Spec
-  include Warden::Spec::Helpers
-
-  before :all do
-    Warden.test_mode!
-  end
+  include Warden::Test::Mock
 
   after do
     Warden.test_reset!
-  end
-
-  def warden
-    @warden ||= begin
-      env = env_with_params
-      setup_rack(success_app).call(env)
-      env['warden']
-    end
   end
 end

--- a/tyrant.gemspec
+++ b/tyrant.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "reform", "~> 2.0"
   spec.add_dependency "disposable", ">= 0.1.11"
 
-  spec.add_dependency "warden"
+  spec.add_dependency "warden", "1.2.6"
   spec.add_dependency "bcrypt"
 end

--- a/tyrant.gemspec
+++ b/tyrant.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rack-minitest"
 
   spec.add_development_dependency "activemodel"
 

--- a/tyrant.gemspec
+++ b/tyrant.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "rack-minitest"
 
   spec.add_development_dependency "activemodel"
 


### PR DESCRIPTION
I used the spec helpers from Warden since it doesn't offer it has a test helper... It must be the real Warden if we want to add other options such as scope or strategies and test them!
