### PR TITLE
Strings vs. Symbols in Warden

### DIFF
--- a/lib/tyrant/railtie.rb
+++ b/lib/tyrant/railtie.rb
@@ -11,7 +11,7 @@ module Tyrant
       end
 
       Warden::Manager.serialize_from_session do |record|
-        record[:model].constantize.find_by(id: record[:id]) # Session.sign_in!(user) or something!
+        record['model'].constantize.find_by(id: record['id']) # Session.sign_in!(user) or something!
       end
     end
   end


### PR DESCRIPTION
By using symbols, Warden (which uses strings for hash key access) will not find the object you were looking for.
