### PR TITLE
Add warden failure app to railtie

### DIFF
--- a/lib/tyrant/railtie.rb
+++ b/lib/tyrant/railtie.rb
@@ -13,6 +13,8 @@ module Tyrant
       Warden::Manager.serialize_from_session do |record|
         record[:model].constantize.find_by(id: record[:id]) # Session.sign_in!(user) or something!
       end
+
+      config.failure_app = -> (_env) { [401, { "Content-Type" => "text/plain" }, ["Authorization Failed"]] }
     end
   end
 end


### PR DESCRIPTION
Fixes "RuntimeError: No Failure App provided", Warden needs a failure app as documented [in the Warden Wiki](https://github.com/hassox/warden/wiki/Setup#rack-setup)