### PR TITLE
Pass through Warden options in sign_in!

### DIFF
--- a/lib/tyrant/session.rb
+++ b/lib/tyrant/session.rb
@@ -14,7 +14,9 @@ module Tyrant
     end
 
     def sign_in!(user, options = {})
-      @warden.set_user(user, scope: options[:scope] || :default)
+      options[:scope] ||= :default
+
+      @warden.set_user(user, options)
     end
 
     # Sign out the default scope only if not specified.

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -64,6 +64,20 @@ class SessionTest < MiniTest::Spec
     assert ! session.signed_in?(scope: :admin)
   end
 
+  describe "#sign_in!" do
+    it 'passes through options to warden' do
+      test_options = { store: false, scope: :admin }
+      user = Object.new
+      warden = Minitest::Mock.new
+      warden.expect(:set_user, nil [user, test_options])
+
+      session = Tyrant::Session.new(warden)
+      session.sign_in!(user, test_options)
+
+      warden.verify
+    end
+  end
+
   it 'sign out only default user if no scope specified' do
     session = Tyrant::Session.new(warden)
 


### PR DESCRIPTION
Currently, `scope` is the only option passed from `sign_in!` to Warden. After this pull request, any options can be passed through.

Unfortunately, tests don't run for me when checking out this gem:

````
[Disposable] The Struct module is deprecated, please use Property::Hash.
/home/nl/workspace/tyrant/lib/tyrant/sign_up.rb:4:in `require': cannot load such file -- reform/form/active_model/validations (LoadError)
        from /home/nl/workspace/tyrant/lib/tyrant/sign_up.rb:4:in `<top (required)>'
        from /home/nl/workspace/tyrant/test/sign_up_test.rb:12:in `require'
        from /home/nl/workspace/tyrant/test/sign_up_test.rb:12:in `<top (required)>'
        from /home/nl/.gem/ruby/2.3.1/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `require'
        from /home/nl/.gem/ruby/2.3.1/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/nl/.gem/ruby/2.3.1/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `select'
        from /home/nl/.gem/ruby/2.3.1/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
````
